### PR TITLE
Match%const

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ppx_const
 =========
 
-This is an OCaml language extension implementing an `if%const` statement. The `if%const` is evaluated at compile time, and the appropriate clause substituted without the ignored clause being fully compiled. This allows you to avoid consequences such as module inclusion or type inference changes which would otherwise have resulted from the ignored clause.
+This is an OCaml language extension implementing `if%const` and `match%const` statements. The `if%const` and `match%const` are evaluated at compile time, and the appropriate clause substituted without the ignored clause(s) being fully compiled. This allows you to avoid consequences such as module inclusion or type inference changes which would otherwise have resulted from the ignored clause(s).
 
 In other words, ppx\_const works like `#if` in the C preprocessor, but is implemented entirely within the OCaml language using the [ppx](http://whitequark.org/blog/2014/04/16/a-guide-to-extension-points-in-ocaml/) mechanism. In conjunction with [ppx_getenv](https://github.com/whitequark/ppx_getenv), this provides a lightweight alternative to Cppo.
 
@@ -24,6 +24,15 @@ COND must be one of the following:
 COND may also contain extension nodes (including `if%const`s) as long as they evaluate to a constant expression by the time ppx\_const sees them.
 
 A and B are not required to be of the same type. Like with normal `if`, the return type of `if%const false then X` is unit.
+
+ppx\_const can also be invoked with the following:
+
+    match%const MATCHED with P_1 -> E_1 | ... | P_n -> E_n
+
+MATCHED and P_1..P_n must be what are considered constants in the AST, i.e. ints, floats, strings, but notably *not* true or false (they're constructors!). Furthermore, the patterns P_1..P_n may be variables or `_`.
+
+If a pattern P_i is a variable `x` the expression, if matched, will compile to `let x = MATCHED in E_i`.
+
 
 An example: Using ppx_const with ppx\_gentenv
 ---------------------------------------------

--- a/src/ppx_const.ml
+++ b/src/ppx_const.ml
@@ -58,11 +58,17 @@ let const_mapper argv =
                               "[%const match...] does not know how to interpret this kind of expression"))
               in
               let check_case (case : case)  = match case with
-                | { pc_guard = None; _ } -> ()
+                | { pc_lhs = { ppat_desc = Ppat_constant _ }; pc_guard = None; _ }
+                | { pc_lhs = { ppat_desc = Ppat_var _ }; pc_guard = None; _ }
+                | { pc_lhs = { ppat_desc = Ppat_any }; pc_guard = None; _ } -> ()
                 | { pc_guard = Some guard; _ } ->
                   raise (Location.Error
                            (Location.error ~loc:guard.pexp_loc
-                              "[%const match...] Guards are not allowed in match%const")) in
+                              "[%const match...] Guards are not allowed in match%const"))
+                | { pc_lhs; _ } ->
+                  raise (Location.Error
+                           (Location.error ~loc:pc_lhs.ppat_loc
+                              "[%const match...] Bad pattern in match%const")) in
               let () = List.iter check_case cases in
               let rec find_match cases = match cases with
                 | case :: cases ->

--- a/src/ppx_const.ml
+++ b/src/ppx_const.ml
@@ -23,28 +23,29 @@ let const_mapper argv =
           begin match process mapper exp with
             (* Currently only match with ifthenelse *)
             | { pexp_loc  = loc;
-                pexp_desc = Pexp_ifthenelse( {pexp_loc=cond_loc;pexp_desc=cond_desc},
-                  then_clause, else_option) } ->
+                pexp_desc = Pexp_ifthenelse (cond, then_clause, else_opt) } ->
               (* Used by = and <> *)
               let pairTest x y op = 
                 match x,y with
                 | Pexp_constant x, Pexp_constant y -> op x y
                 | _ ->
                   raise (Location.Error (
-                      Location.error ~loc:cond_loc "[%const if...] does not know how to compare these two expressions"))
+                      Location.error ~loc:cond.pexp_loc "[%const if...] does not know how to compare these two expressions"))
               in
               (* Evaluate conditional *)
-              let which = match cond_desc with
-                | Pexp_construct ({txt=Lident "true"},None) -> true
-                | Pexp_construct ({txt=Lident "false"},None) -> false
-                | Pexp_apply( {pexp_desc=Pexp_ident({txt=Lident "=" })}, [_,{pexp_desc=x};_,{pexp_desc=y}] ) -> pairTest x y (=)
-                | Pexp_apply( {pexp_desc=Pexp_ident({txt=Lident "<>"})}, [_,{pexp_desc=x};_,{pexp_desc=y}] ) -> pairTest x y (<>)
+              let which = match cond with
+                | [%expr true] -> true
+                | [%expr false] -> false
+                | [%expr [%e? x] = [%e? y]] ->
+                  pairTest x.pexp_desc y.pexp_desc (=)
+                | [%expr [%e? x] <> [%e? y]] ->
+                  pairTest x.pexp_desc y.pexp_desc (<>)
                 | _ ->
                   raise (Location.Error (
-                      Location.error ~loc:cond_loc "[%const if...] does not know how to interpret this kind of expression"))
+                      Location.error ~loc:cond.pexp_loc "[%const if...] does not know how to interpret this kind of expression"))
               in
               (* Depending on value of conditional, replace self extension node with either the then or else clause contents *)
-              if which then then_clause else (match else_option with Some x -> x | _ ->
+              if which then then_clause else (match else_opt with Some x -> x | _ ->
                 (* Or, if the else clause is selected but is not specified, a () *)
                 Ast_helper.with_default_loc loc (fun _ -> Ast_convenience.unit ()))
             (* Failed to match Pexp_ifthenelse, so fail *)

--- a/src/ppx_const.ml
+++ b/src/ppx_const.ml
@@ -28,10 +28,10 @@ let const_mapper argv =
               (* Used by = and <> *)
               let pairTest x y op = 
                 match x,y with
-                    | Pexp_constant x, Pexp_constant y -> op x y
-                    | _ ->
-                      raise (Location.Error (
-                        Location.error ~loc:cond_loc "[%const if...] does not know how to compare these two expressions"))
+                | Pexp_constant x, Pexp_constant y -> op x y
+                | _ ->
+                  raise (Location.Error (
+                      Location.error ~loc:cond_loc "[%const if...] does not know how to compare these two expressions"))
               in
               (* Evaluate conditional *)
               let which = match cond_desc with
@@ -47,8 +47,8 @@ let const_mapper argv =
               if which then then_clause else (match else_option with Some x -> x | _ ->
                 (* Or, if the else clause is selected but is not specified, a () *)
                 Ast_helper.with_default_loc loc (fun _ -> Ast_convenience.unit ()))
-          (* Failed to match Pexp_ifthenelse, so fail *)
-          | _ -> didnt_find_if loc
+            (* Failed to match Pexp_ifthenelse, so fail *)
+            | _ -> didnt_find_if loc
           end
         (* Failed to match Pstr, so fail *)
         | _ -> didnt_find_if loc

--- a/src/ppx_const.ml
+++ b/src/ppx_const.ml
@@ -50,6 +50,13 @@ let const_mapper argv =
                 Ast_helper.with_default_loc loc (fun _ -> Ast_convenience.unit ()))
             | { pexp_loc = match_loc;
                 pexp_desc = Pexp_match (match_expr, cases) } ->
+              let () = match match_expr.pexp_desc with
+                | Pexp_constant _ -> ()
+                | _ ->
+                  raise (Location.Error
+                           (Location.error ~loc:match_expr.pexp_loc
+                              "[%const match...] does not know how to interpret this kind of expression"))
+              in
               let check_case (case : case)  = match case with
                 | { pc_guard = None; _ } -> ()
                 | { pc_guard = Some guard; _ } ->

--- a/src/ppx_const.ml
+++ b/src/ppx_const.ml
@@ -73,7 +73,9 @@ let const_mapper argv =
               let rec find_match cases = match cases with
                 | case :: cases ->
                   begin match case.pc_lhs.ppat_desc with
-                    | Ppat_any | Ppat_var _ -> case.pc_rhs
+                    | Ppat_any -> case.pc_rhs
+                    | Ppat_var _ ->
+                      [%expr let [%p case.pc_lhs] = [%e match_expr] in [%e case.pc_rhs]]
                     | Ppat_constant const ->
                       if match_expr.pexp_desc = Pexp_constant const
                       then case.pc_rhs

--- a/src_test/test_ppx_const.ml
+++ b/src_test/test_ppx_const.ml
@@ -11,7 +11,8 @@ let test_ppx_const _ =
   (* Fails because true is a constructor, not a constant *)
   (*assert_equal "match2"   @@ (match%const true with true -> "match2" | false -> "bogus");*)
   assert_equal "match3"   @@ (match%const 3 with 1 -> () | 3 -> "match3" | 3 -> "bogus");
-  assert_equal 8          @@ 3 + (match%const "five" with "goodbye type safety" -> () | "five" -> 5)
+  assert_equal 8          @@ 3 + (match%const "five" with "goodbye type safety" -> () | "five" -> 5);
+  assert_equal "match5"   @@ "match" ^ string_of_int (match%const 4 with 11 -> 11 | four -> four + 1)
 
 
 let suite = "Test ppx_const" >::: [

--- a/src_test/test_ppx_const.ml
+++ b/src_test/test_ppx_const.ml
@@ -11,8 +11,7 @@ let test_ppx_const _ =
   (* Fails because true is a constructor, not a constant *)
   (*assert_equal "match2"   @@ (match%const true with true -> "match2" | false -> "bogus");*)
   assert_equal "match3"   @@ (match%const 3 with 1 -> () | 3 -> "match3" | 3 -> "bogus");
-  assert_equal 8          @@ 3 + (match%const "five" with "goodbye type safety" -> () | "five" -> 5);
-  assert_equal "abc"      @@ "a" ^ (match%const assert false with _ -> "b" ^ match%const 1 ^ 2 with  _ -> "c")
+  assert_equal 8          @@ 3 + (match%const "five" with "goodbye type safety" -> () | "five" -> 5)
 
 
 let suite = "Test ppx_const" >::: [

--- a/src_test/test_ppx_const.ml
+++ b/src_test/test_ppx_const.ml
@@ -6,7 +6,14 @@ let test_ppx_const _ =
   assert_equal "BLAAAARG" @@ if false then "WRONG" else if%const 3=4 then 4 else "BLAAAARG";
   assert_equal "...blarg" @@ if%const true then (if%const false then 5 else "...blarg") else 3;
   assert_equal "Blarg."   @@ if%const 2=if%const 1=0 then 3 else 2 then "Blarg." else 1;
-  assert_equal "Blarg"    @@ if%const 3 <> 3 then 4 else if%const 4 <> 3 then "Blarg" else 6
+  assert_equal "Blarg"    @@ if%const 3 <> 3 then 4 else if%const 4 <> 3 then "Blarg" else 6;
+  assert_equal "match1"   @@ (match%const 42 with _ -> "match1");
+  (* Fails because true is a constructor, not a constant *)
+  (*assert_equal "match2"   @@ (match%const true with true -> "match2" | false -> "bogus");*)
+  assert_equal "match3"   @@ (match%const 3 with 1 -> () | 3 -> "match3" | 3 -> "bogus");
+  assert_equal 8          @@ 3 + (match%const "five" with "goodbye type safety" -> () | "five" -> 5);
+  assert_equal "abc"      @@ "a" ^ (match%const assert false with _ -> "b" ^ match%const 1 ^ 2 with  _ -> "c")
+
 
 let suite = "Test ppx_const" >::: [
     "test_ppx_const" >:: test_ppx_const;


### PR DESCRIPTION
This is maybe more a request for comments than a PR proper.

This adds match%const expressions. This matches on the AST's notion of constants, that is ints, floats, strings, etc, but notably not bools since they're actually variants(!)
- Wildcard patterns are allowed `match%const 1 with _ -> e2`
- Variable patterns are also allowed `match%const 1 with x -> x + 1` and compiles to a let expression `let x = 1 in x + 1`
- Unreachable patterns are silently ignored

I've used the ppx_tools.metaquot extension when possible to match and construct expressions, in the new code as well as the existing code.

I have also made some minor changes regarding indentation and variable naming.

I'd be happy to make any changes and resubmit a PR.
