### PR TITLE
Make ppx_const compatible with ppxlib.0.18.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,10 +11,10 @@
 (source (github mcclure/ppx_const))
 (package
   (name ppx_const)
-  (synopsis "Compile-time \"if\" statement for conditional inclusion of code.")
+  (synopsis "Compile-time \"if\" statement for conditional inclusion of code")
   (description "\
 This is a ppx extension which adds `if#const` and `match#const` constructs to
-OCaml. They behave like normal `if` and `const`, but conditions are evaluated
+OCaml. They behave like normal `if` and `match`, but conditions are evaluated
 at compile time and AST sections not selected are excluded from the program
 completely. In conjunction with ppx_getenv, this can be used for conditional
 compilation of code.
@@ -22,7 +22,7 @@ compilation of code.
   (tags ("syntax"))
   (depends
     (ocaml (>= 4.04.0))
-    (ppxlib (>= 0.9.0))
+    (ppxlib (>= 0.18.0))
     (ounit2 :with-test)
     (ppx_getenv (and :with-test (>= 2.0)))
     (odoc :with-doc)))

--- a/ppx_const.opam
+++ b/ppx_const.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/mcclure/ppx_const/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.04.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.18.0"}
   "ounit2" {with-test}
   "ppx_getenv" {with-test & >= "2.0"}
   "odoc" {with-doc}

--- a/src/ppx_const.ml
+++ b/src/ppx_const.ml
@@ -25,7 +25,7 @@ let const_eq x y = match x, y with
       String.equal x y
   | Pconst_char x, Pconst_char y ->
       Char.equal x y
-  | Pconst_string (x, _delim1), Pconst_string (y, _delim2) ->
+  | Pconst_string (x, _, _delim1), Pconst_string (y, _, _delim2) ->
       String.equal x y
   | Pconst_float (x, _suff1), Pconst_float (y, _suff2) ->
       (* Ignore suffixes. It doesn't really matter if they're different types


### PR DESCRIPTION
ppxlib.0.18.0 updates its internal AST to 4.11 resulting in a change in string constant representation. This PR makes ppx_const compatible with the latest ppxlib.

You will probably want to wait for the ppxlib release to go through before merging this!